### PR TITLE
feat: channel webhooks

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -5,6 +5,7 @@ import { EventClient, EventClientOptions } from "./events/EventClient.js";
 import {
   ChannelCollection,
   ChannelUnreadCollection,
+  ChannelWebhookCollection,
   EmojiCollection,
   MessageCollection,
   ServerCollection,
@@ -130,6 +131,7 @@ export class Client extends AsyncEventEmitter<Events> {
   readonly emojis = new EmojiCollection(this);
   readonly events: EventClient<1>;
   readonly messages = new MessageCollection(this);
+  readonly channelWebhooks = new ChannelWebhookCollection(this);
   readonly options: ClientOptions;
   // @ts-ignore unused
   private ready: boolean = false;

--- a/src/collections/ChannelWebhookCollection.ts
+++ b/src/collections/ChannelWebhookCollection.ts
@@ -1,0 +1,21 @@
+import { CreateWebhookBody, Webhook } from "revolt-api";
+import { Client } from "../Client.js";
+import { Channel, ChannelWebhook } from "../models/index.js";
+import { CachedCollection } from "./DataCollection.js";
+
+export class ChannelWebhookCollection extends CachedCollection<ChannelWebhook> {
+  constructor(client: Client) {
+    super(client, ChannelWebhook);
+  }
+
+  create(channel: Channel, data: Webhook) {
+    const webhook = new ChannelWebhook(channel, data);
+    this.cache.set(webhook.id, webhook);
+    return webhook;
+  }
+
+  async createWebhook(channel: Channel, data: CreateWebhookBody) {
+    const result = await this.client.api.post(`/channels/${channel.id as ""}/webhooks`, data);
+    return this.create(channel, result);
+  }
+}

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -1,5 +1,6 @@
 export * from "./ChannelCollection.js";
 export * from "./ChannelUnreadCollection.js";
+export * from "./ChannelWebhookCollection.js";
 export * from "./DataCollection.js";
 export * from "./EmojiCollection.js";
 export * from "./MessageCollection.js";

--- a/src/models/Channel.ts
+++ b/src/models/Channel.ts
@@ -160,6 +160,16 @@ export class Channel extends Base {
   }
 
   /**
+   * Fetch a channel's webhooks
+   * @requires `TextChannel`, `Group`
+   */
+  async fetchWebhooks() {
+    const webhooks = await this.client.api.get(`/channels/${this.id as ""}/webhooks`);
+
+    return webhooks.map((webhook) => this.client.channelWebhooks.create(this, webhook));
+  }
+
+  /**
    * Edit a channel
    * @param data Changes
    */

--- a/src/models/ChannelWebhook.ts
+++ b/src/models/ChannelWebhook.ts
@@ -1,0 +1,33 @@
+import { Webhook } from "revolt-api";
+
+import { AutumnFile, Base, Channel } from "./index.js";
+import { PermissionsBitField } from "../permissions/ops.js";
+
+export class ChannelWebhook extends Base {
+  avatar: AutumnFile | null = null;
+  readonly creatorId: string;
+  readonly id: string;
+  name: string;
+  permissions: PermissionsBitField;
+  token: string | null = null;
+
+  constructor(
+    channel: Channel,
+    readonly data: Webhook,
+  ) {
+    super(channel.client);
+    this.id = data.id;
+    this.name = data.name;
+    this.creatorId = data.creator_id;
+    this.permissions = new PermissionsBitField(data.permissions);
+    this.update(data);
+  }
+
+  override update(data: Partial<Webhook>) {
+    if ("name" in data) this.name = data.name;
+    if ("avatar" in data) this.avatar = data.avatar ? new AutumnFile(this.client, data.avatar) : null;
+    if ("permissions" in data) this.permissions = new PermissionsBitField(data.permissions);
+    if ("token" in data) this.token = data.token;
+    return this;
+  }
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -9,6 +9,7 @@ export * from "./Channel.js";
 export * from "./ChannelUnread.js";
 export * from "./DMChannel.js";
 export * from "./GroupChannel.js";
+export * from "./ChannelWebhook.js";
 
 export * from "./Emoji.js";
 export * from "./File.js";


### PR DESCRIPTION
Se crea un modelo ChannelWebhook y una colección de este modelo. La colección se asocia al cliente, pero para crear un webhook por la API será requisito una instancia Channel para evitar que `ChannelWebhook#channel` resulte null.

Interacciones:
- `ChannelWebhookCollection#createWebhook`: Crea un webhook y lo agrega a la colección.
- `Channel#fetchWebhooks`: Recupera todos los webhooks del canal, los agrega a la colección del cliente y retorna como `ChannelWebhook[]`