### PR TITLE
feat: server channel invite & group invite

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -29,7 +29,6 @@ import type { Server } from "./models/Server.js";
 import type { ServerMember } from "./models/ServerMember.js";
 import type { User } from "./models/User.js";
 
-
 type Token = string;
 export type Session = { _id: string; token: Token; user_id: string } | Token;
 
@@ -360,7 +359,7 @@ export class Client extends AsyncEventEmitter<Events> {
         return {
           users: result.users.map((user) => this.users.create(user)),
           group: this.channels.create(result.channel),
-        }
+        };
       case "Server":
         const server = this.servers.create(result.server);
         const channels = result.channels.map((channel) => this.channels.create(channel));
@@ -368,7 +367,7 @@ export class Client extends AsyncEventEmitter<Events> {
         return {
           server,
           channels,
-        }
+        };
     }
   }
 

--- a/src/collections/ChannelCollection.ts
+++ b/src/collections/ChannelCollection.ts
@@ -85,8 +85,8 @@ export class ChannelCollection extends CachedCollection<Channel> {
   }
 }
 
-export class ChannelCollectionInServer extends CachedCollection<Channel> {
+export class ChannelCollectionInServer extends ChannelCollection {
   constructor(server: Server) {
-    super(server.client, Channel);
+    super(server.client);
   }
 }

--- a/src/collections/InviteCollection.ts
+++ b/src/collections/InviteCollection.ts
@@ -1,0 +1,61 @@
+import { CachedCollection } from "./DataCollection.js";
+import { GroupInvite, GroupInviteData, Invite, ServerInvite, ServerInviteData } from "../models/Invite.js";
+import { Server } from "../models/Server.js";
+import { Channel } from "../models/Channel.js";
+
+export class InviteCollection extends CachedCollection<Invite> {
+  // Abstract constructor
+
+  /**
+   * Delete an invite by its id.
+   * @throws RevoltAPIError
+   */
+  async delete(id: string) {
+    await this.client.api.delete(`/invites/${id as ""}`);
+    return this._remove(id);
+  }
+}
+
+export class GroupInviteCollection extends CachedCollection<GroupInvite> {
+  constructor(target: Channel) {
+    super(target.client, GroupInvite);
+  }
+
+  create(data: GroupInviteData) {
+    const invite = new GroupInvite(this.client, data);
+    this.cache.set(invite.id, invite);
+    return invite;
+  }
+
+  /**
+   * Creates an invite to the group by its id.
+   * @throws RevoltAPIError
+   */
+  async createInvite(id: string) {
+    const result = await this.client.api.post(`/channels/${id as ""}/invites`);
+    if (result.type == "Group") return this.create(result);
+    throw new TypeError(`Invite type ${result.type} is not supported by GroupInviteCollection.`);
+  }
+}
+
+export class ServerInviteCollection extends InviteCollection {
+  constructor(target: Server) {
+    super(target.client, ServerInvite);
+  }
+
+  create(data: ServerInviteData) {
+    const invite = new ServerInvite(this.client, data);
+    this.cache.set(invite.id, invite);
+    return invite;
+  }
+
+  /**
+   * Creates an invite to the server channel by its id.
+   * @throws RevoltAPIError
+   */
+  async createInvite(id: string) {
+    const result = await this.client.api.post(`/channels/${id as ""}/invites`);
+    if (result.type == "Server") return this.create(result);
+    throw new TypeError(`Invite type ${result.type} is not supported by ServerInviteCollection.`);
+  }
+}

--- a/src/collections/ServerCollection.ts
+++ b/src/collections/ServerCollection.ts
@@ -14,4 +14,11 @@ export class ServerCollection extends CachedCollection<Server> {
     this.cache.set(data._id, server);
     return server;
   }
+
+  update(id: string, data: Partial<ApiServer>) {
+    const server = this.cache.get(id);
+    if (server) {
+      return server.update(data);
+    }
+  }
 }

--- a/src/errors/ErrorCodes.ts
+++ b/src/errors/ErrorCodes.ts
@@ -1,10 +1,12 @@
 export enum ErrorCodes {
+  NotFoundById = "NoSuchElement",
   UnreachableCode = "UnreachableCode",
   UserDMNotFound = "UserDMNotFound",
   UserNoDiscriminator = "UserNoDiscriminator",
 }
 
 export const Messages: Record<ErrorCodes, string | ((...args: string[]) => string)> = {
+  [ErrorCodes.NotFoundById]: (type, id) => `No ${type} found by ID ${id}.`,
   [ErrorCodes.UnreachableCode]: "Unreachable code.",
   [ErrorCodes.UserDMNotFound]: "User DM channel not found.",
   [ErrorCodes.UserNoDiscriminator]: "String must contain username#discriminator combo.",

--- a/src/models/GroupChannel.ts
+++ b/src/models/GroupChannel.ts
@@ -4,6 +4,7 @@ import { Channel } from "./Channel.js";
 import { AutumnFile } from "./File.js";
 import type { User } from "./User.js";
 import { DEFAULT_PERMISSION_DIRECT_MESSAGE, Permission } from "../permissions/index.js";
+import { GroupInviteCollection } from "../collections/InviteCollection.js";
 
 export type GroupData = Extract<ApiChannel, { channel_type: "Group" }>;
 
@@ -11,6 +12,7 @@ export class Group extends Channel {
   name: string;
   description: string | null;
   icon: AutumnFile | null;
+  readonly invites = new GroupInviteCollection(this);
   ownerId: string;
   permissions: number | null;
   readonly recipientIds: Set<string>;
@@ -37,6 +39,10 @@ export class Group extends Channel {
     const user = this.client.user;
     if (user?.permission) return user.permission;
     return this.ownerId == user?.id ? Permission.GrantAllSafe : (this.permissions ?? DEFAULT_PERMISSION_DIRECT_MESSAGE);
+  }
+
+  createInvite() {
+    return this.invites.createInvite(this.id);
   }
 
   /**

--- a/src/models/Invite.ts
+++ b/src/models/Invite.ts
@@ -1,0 +1,131 @@
+import type { Channel, InviteResponse, Invite as ApiInvite, Server, User } from "revolt-api";
+
+import { Base } from "./Base.js";
+import type { Client } from "../Client.js";
+import type { Group } from "./GroupChannel.js";
+import type { TextChannel } from "./ServerChannel.js";
+
+type GroupInviteData = Extract<ApiInvite, { type: "Group" }>;
+type GroupFullInviteData = Extract<InviteResponse, { type: "Group" }>;
+type ServerInviteData = Extract<ApiInvite, { type: "Server" }>;
+type ServerFullInviteData = Extract<InviteResponse, { type: "Server" }>;
+
+/**
+ * Invite including the creator data
+ */
+export class FullInvite extends Base {
+  readonly code: string;
+  readonly creatorData: Partial<User>;
+  readonly type: "Group" | "Server";
+  constructor(client: Client, data: InviteResponse) {
+    super(client);
+    this.code = data.code;
+    this.type = data.type;
+    this.creatorData = {
+      username: data.user_name,
+      avatar: data.user_avatar || null,
+    };
+  }
+
+  get id() {
+    return this.code;
+  }
+}
+
+export class Invite extends Base {
+  readonly id: string;
+  readonly creatorId: string;
+  readonly type: "Group" | "Server";
+  constructor(client: Client, data: ApiInvite) {
+    super(client);
+    this.id = data._id;
+    this.creatorId = data.creator;
+    this.type = data.type;
+  }
+
+  get creator() {
+    return this.client.users.resolve(this.creatorId);
+  }
+}
+
+export class GroupInvite extends Invite {
+  readonly channelId: string;
+  constructor(client: Client, data: GroupInviteData) {
+    super(client, data);
+    this.channelId = data.channel;
+  }
+
+  get channel() {
+    return this.client.channels.resolve(this.channelId);
+  }
+}
+
+/**
+ * Invite including creator and group channel data
+ */
+export class GroupFullInvite extends FullInvite {
+  readonly channelData: Partial<Channel> & { _id: string };
+  constructor(client: Client, data: GroupFullInviteData) {
+    super(client, data);
+    this.channelData = {
+      _id: data.channel_id,
+      name: data.channel_name,
+      description: data.channel_description,
+    };
+  }
+
+  get channel() {
+    return this.client.channels.update(this.channelData._id, this.channelData) as Group | null;
+  }
+}
+
+/**
+ * Invite including member count, and creator, server, and channel data
+ */
+export class ServerFullInvite extends FullInvite {
+  readonly serverData: Partial<Server> & { _id: string };
+  readonly channelData: Partial<Channel> & { _id: string };
+  readonly memberCount: number;
+  constructor(client: Client, data: ServerFullInviteData) {
+    super(client, data);
+    this.memberCount = data.member_count;
+    this.channelData = {
+      name: data.channel_name,
+      description: data.channel_description,
+      _id: data.channel_id,
+    };
+    this.serverData = {
+      _id: data.server_id,
+      banner: data.server_banner,
+      flags: data.server_flags || undefined,
+      icon: data.server_icon,
+      name: data.server_name,
+    } as Server; // Silent typing error
+  }
+
+  get channel() {
+    return this.client.channels.update(this.channelData._id, this.channelData) as TextChannel | null;
+  }
+
+  get server() {
+    return this.client.servers.update(this.serverData._id, this.serverData);
+  }
+}
+
+export class ServerInvite extends Invite {
+  readonly channelId: string;
+  readonly serverId: string;
+  constructor(client: Client, data: ServerInviteData) {
+    super(client, data);
+    this.serverId = data.server;
+    this.channelId = data.channel;
+  }
+
+  get channel() {
+    return this.client.channels.resolve(this.channelId);
+  }
+
+  get server() {
+    return this.client.servers.resolve(this.serverId);
+  }
+}

--- a/src/models/Invite.ts
+++ b/src/models/Invite.ts
@@ -5,9 +5,9 @@ import type { Client } from "../Client.js";
 import type { Group } from "./GroupChannel.js";
 import type { TextChannel } from "./ServerChannel.js";
 
-type GroupInviteData = Extract<ApiInvite, { type: "Group" }>;
+export type GroupInviteData = Extract<ApiInvite, { type: "Group" }>;
 type GroupFullInviteData = Extract<InviteResponse, { type: "Group" }>;
-type ServerInviteData = Extract<ApiInvite, { type: "Server" }>;
+export type ServerInviteData = Extract<ApiInvite, { type: "Server" }>;
 type ServerFullInviteData = Extract<InviteResponse, { type: "Server" }>;
 
 /**

--- a/src/models/Server.ts
+++ b/src/models/Server.ts
@@ -13,6 +13,7 @@ import { PermissionsBitField } from "../permissions/PermissionsBitField.js";
 import { ALLOW_IN_TIMEOUT, Permission, PermissionOverrides } from "../permissions/index.js";
 import { BitField } from "../utils/BitField.js";
 import { ServerInviteCollection } from "../collections/InviteCollection.js";
+import { ServerInviteData } from "./Invite.js";
 
 export class Server extends Base {
   // @ts-ignore unused
@@ -96,6 +97,15 @@ export class Server extends Base {
           break;
       }
     }
+  }
+
+  /**
+   * Fetch all server invites.
+   * @throws RevoltAPIError
+   */
+  async fetchInvites() {
+    const invites = (await this.client.api.get(`/servers/${this.id as ""}/invites`)) as ServerInviteData[]; // Assuming the API filters server invites
+    return invites.map((invite) => this.invites.create(invite));
   }
 
   /**

--- a/src/models/Server.ts
+++ b/src/models/Server.ts
@@ -12,6 +12,7 @@ import { ServerMemberCollection } from "../collections/ServerMemberCollection.js
 import { PermissionsBitField } from "../permissions/PermissionsBitField.js";
 import { ALLOW_IN_TIMEOUT, Permission, PermissionOverrides } from "../permissions/index.js";
 import { BitField } from "../utils/BitField.js";
+import { ServerInviteCollection } from "../collections/InviteCollection.js";
 
 export class Server extends Base {
   // @ts-ignore unused
@@ -21,6 +22,7 @@ export class Server extends Base {
   readonly categories = new ServerCategoryCollection(this);
   readonly channels = new ChannelCollectionInServer(this);
   readonly defaultPermissions: PermissionsBitField;
+  readonly invites = new ServerInviteCollection(this);
   readonly members = new ServerMemberCollection(this);
   roles = new RoleCollection(this);
   discoverable = false;

--- a/src/models/ServerChannel.ts
+++ b/src/models/ServerChannel.ts
@@ -18,6 +18,8 @@ import type { User } from "./User.js";
 import { PermissionsBitField } from "../permissions/PermissionsBitField.js";
 import Long from "long";
 import { BitField } from "../utils/BitField.js";
+import { RJSError } from "../errors/RJSError.js";
+import { ErrorCodes } from "../errors/ErrorCodes.js";
 
 type ServerChannelData = Extract<ApiChannel, { channel_type: "TextChannel" | "VoiceChannel" }>;
 export class ServerChannel extends TextBasedChannel {
@@ -107,13 +109,13 @@ export class ServerChannel extends TextBasedChannel {
       return perm.toNumber();
     }
   }
+
   /**
    * Creates an invite to this channel.
    * @throws RevoltAPIError
    */
-  async createInvite() {
-    // TODO: Invite model
-    return await this.client.api.post(`/channels/${this.id as ""}/invites`);
+  createInvite() {
+    return this.server.invites.createInvite(this.id);
   }
 
   /**
@@ -161,7 +163,9 @@ export class ServerChannel extends TextBasedChannel {
   }
 
   get server() {
-    return this.client.servers.resolve(this.serverId);
+    const server = this.client.servers.resolve(this.serverId);
+    if (!server) throw new RJSError(ErrorCodes.NotFoundById, "server", this.serverId);
+    return server;
   }
 
   /**

--- a/tests/invite.mjs
+++ b/tests/invite.mjs
@@ -1,0 +1,9 @@
+import { Client } from "../lib/esm/index.js";
+
+const client = new Client({ debug: true });
+const code = "Testers";
+
+client
+  .fetchFullInvite(code)
+  .then((invite) => console.log("Server name: %s\nMember count: %d", invite.serverData.name, invite.memberCount))
+  .catch(console.error);


### PR DESCRIPTION
Metodos:
- `Client#fetchFullInvite` - Retorna una instancia de GroupFullInvite o ServerFullInvite, estas estructuras intentan recuperar el creador de la invitacion, el canal y el servidor desde la caché, en caso de fallo existen `creatorData`, `channelData` y `serverData` como objetos planos
- `InviteCollection#delete` - Elimina una invitación sin importar su tipo
- `GroupInviteCollection#createInvite` y `ServerInviteCollection#createInvite` - Crean la invitacion desde la ID correspondiente, tira error si el tipo de invitacion no corresponde con el tipo de colección (se evita que se mezclen los datos)
- `Server#fetchInvites` - Obtiene una lista de invitaciones, para que sea compatible con `ServerInviteCollection` se asume que todos los elementos son tipo Server