### PR TITLE
Feat: Manual login

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -350,7 +350,7 @@ export class Client extends AsyncEventEmitter<Events> {
    */
   async completeOnboarding(username: string) {
     if (typeof username != "string") throw new TypeError("username must be a string");
-    if (!username.match(/^(\p{L}|[\d_.-])+$/v)) {
+    if (!username.match(/^(\p{L}|[\d_.\-])+$/v)) {
       throw new TypeError(
         "username provided is not valid (it should contain only letters, digits, underscores, dashes, and periods)",
       );
@@ -421,6 +421,7 @@ export class Client extends AsyncEventEmitter<Events> {
     switch (result) {
       case "Success":
         this.#session = loginResult;
+        this.#updateHeaders();
         await this.connect();
         break;
       case "MFA":

--- a/src/errors/ErrorCodes.ts
+++ b/src/errors/ErrorCodes.ts
@@ -1,11 +1,15 @@
 export enum ErrorCodes {
+  AccountDisabled = "AccountDisabled",
   NotFoundById = "NoSuchElement",
+  MFANotImplemented = "MFANotImplemented",
   UnreachableCode = "UnreachableCode",
   UserDMNotFound = "UserDMNotFound",
   UserNoDiscriminator = "UserNoDiscriminator",
 }
 
 export const Messages: Record<ErrorCodes, string | ((...args: string[]) => string)> = {
+  [ErrorCodes.AccountDisabled]: (id) => `Account ${id} is disabled.`,
+  [ErrorCodes.MFANotImplemented]: "MFA is not implemented.",
   [ErrorCodes.NotFoundById]: (type, id) => `No ${type} found by ID ${id}.`,
   [ErrorCodes.UnreachableCode]: "Unreachable code.",
   [ErrorCodes.UserDMNotFound]: "User DM channel not found.",

--- a/src/errors/RevoltAPIError.ts
+++ b/src/errors/RevoltAPIError.ts
@@ -1,5 +1,11 @@
 import { Error as APIError } from "revolt-api";
 
+export interface HttpError {
+  code: number;
+  reason: string;
+  description: string;
+}
+
 export class RevoltAPIError extends Error {
   public constructor(
     public rawError: APIError,
@@ -17,7 +23,7 @@ export class RevoltAPIError extends Error {
     return `${RevoltAPIError.name}[${this.status}]`;
   }
 
-  private static getMessage(error: APIError) {
+  private static getMessage(error: APIError | HttpError) {
     if ("type" in error) {
       switch (error.type) {
         case "MissingPermission":
@@ -38,6 +44,10 @@ export class RevoltAPIError extends Error {
           const { type, location, ...data } = error;
           return `${error.type}\n\n${JSON.stringify(data)}`;
       }
+    }
+
+    if ("reason" in error) {
+      return `${error.reason}\n${error.description}`;
     }
 
     return "No Description";

--- a/tests/selfbot.mjs
+++ b/tests/selfbot.mjs
@@ -1,0 +1,31 @@
+import "dotenv/config";
+import { Client, Permission } from "../lib/esm/index.js";
+
+const client = new Client({ debug: true });
+
+client.on("ready", () => console.log(`Logged in as ${client.user.username}#${client.user.discriminator}`));
+
+client.on("messageCreate", async (message) => {
+  console.log(`${message.author.username}#${message.author.discriminator}: ${message.content}`);
+
+  try {
+    if (message.content == "!ping") {
+      if (!message.channel.havePermission(Permission.SendMessage)) {
+        console.error("Bot does not have permission to send messages in this channel! (Channel ID: %s)", message.channelId);
+        return;
+      }
+      await message.reply("Pong!");
+    }
+  } catch (error) {
+    console.error(error);
+  }
+});
+
+client.on("disconnected", () => console.log("Disconnected"));
+
+client.login(process.env.USER_TOKEN).then(result => {
+  if (result.callback) {
+    result.callback("username").then(user => console.log(`Completed onboarding as ${user.username}#${user.discriminator}`));
+  }
+  console.log("Authenticated");
+});

--- a/tests/selfbot.mjs
+++ b/tests/selfbot.mjs
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import { Client, Permission } from "../lib/esm/index.js";
 
+const { ACCOUNT_EMAIL: email, ACCOUNT_PASSWORD: password, OS } = process.env;
 const client = new Client({ debug: true });
 
 client.on("ready", () => console.log(`Logged in as ${client.user.username}#${client.user.discriminator}`));
@@ -23,9 +24,10 @@ client.on("messageCreate", async (message) => {
 
 client.on("disconnected", () => console.log("Disconnected"));
 
-client.login(process.env.USER_TOKEN).then(result => {
-  if (result.callback) {
-    result.callback("username").then(user => console.log(`Completed onboarding as ${user.username}#${user.discriminator}`));
+client.login({ email, password, friendly_name: `Node.js on ${OS}` }).then(result => {
+  if (result?.callback) {
+    console.log("Required onboarding");
+    // result.callback("your_username");
   }
   console.log("Authenticated");
-});
+}).catch(console.error);


### PR DESCRIPTION
Simple implementacion que permite login con correo y contraseña. para integración con frontend.
Se corrige un pequeño bug en el formato de errores de API, donde debido a un error interno del backend se recibe un objeto `{error: {...}`. El formato para ese tipo de errores queda:
RevoltAPIError[`code`]: `reason`
`description`